### PR TITLE
Add missing builder functions for FBI and Thai restaurant buildings

### DIFF
--- a/js/buildings.js
+++ b/js/buildings.js
@@ -6622,6 +6622,663 @@ CUSTOM_BUILDERS['the-aussie-escape'] = function (group, building) {
   buildPlaque(group, building, D / 2 + 0.1, 1.5);
 };
 
+CUSTOM_BUILDERS['federal-bureau-of-ai-investigation'] = function (group, building) {
+  // ── DIMENSIONS ──────────────────────────────────────────────────────────────
+  const W      = 6.0;   // full width of upper body
+  const D      = 2.5;   // full depth of upper body
+  const gndH   = 1.2;   // ground floor height
+  const flrH   = 1.5;   // each upper floor height
+  const upperH = flrH * 2;       // 3.0 — two upper floors
+  const totalH = gndH + upperH;  // 4.2
+  const overhang = 0.3;
+  const gndW   = W - 2 * overhang;  // 5.4 — ground floor width
+  const gndD   = D - 2 * overhang;  // 1.9 — ground floor depth
+  const baseY  = 0.1;               // foundation height
+
+  // ── MATERIALS ────────────────────────────────────────────────────────────────
+  const concMat    = new THREE.MeshStandardMaterial({ color: 0x8C8C8C, roughness: 0.9 });
+  const gndBodyMat = new THREE.MeshStandardMaterial({ color: 0x6B6B6B, roughness: 0.9 });
+  const bayMat     = new THREE.MeshStandardMaterial({ color: 0x4A4A4A, roughness: 0.9 });
+  const limeMat    = new THREE.MeshStandardMaterial({ color: 0xB0A89A, roughness: 0.8 });
+  const doorMat    = new THREE.MeshStandardMaterial({ color: 0x2C3E50, roughness: 0.5 });
+  const goldMat    = new THREE.MeshStandardMaterial({ color: 0xDAA520, metalness: 0.4, roughness: 0.4 });
+  const dkGoldMat  = new THREE.MeshStandardMaterial({ color: 0xB8860B, metalness: 0.3, roughness: 0.5 });
+  const roofMat    = new THREE.MeshStandardMaterial({ color: 0x7A7A7A, roughness: 0.9 });
+  const mechMat    = new THREE.MeshStandardMaterial({ color: 0x5A5A5A, roughness: 0.8 });
+  const antMat     = new THREE.MeshStandardMaterial({ color: 0x404040, roughness: 0.6 });
+  const barrMat    = new THREE.MeshStandardMaterial({ color: 0x999999, roughness: 0.9 });
+  const poleMat    = new THREE.MeshStandardMaterial({ color: 0xC0C0C0, metalness: 0.5, roughness: 0.3 });
+  const starMat    = new THREE.MeshStandardMaterial({ color: 0xFFD700, metalness: 0.3, roughness: 0.3 });
+  const winMat     = new THREE.MeshStandardMaterial({
+    color: 0xbfdbfe, emissive: 0x3b82f6, emissiveIntensity: 0.12,
+    transparent: true, opacity: 0.35, roughness: 0.1,
+  });
+  const deskMat    = new THREE.MeshStandardMaterial({ color: 0x8B7355 });
+  const detectorMat = new THREE.MeshStandardMaterial({ color: 0x404040 });
+  const walnutMat  = new THREE.MeshStandardMaterial({ color: 0x5C4033 });
+  const boardMat   = new THREE.MeshStandardMaterial({ color: 0xF5F5DC });
+  const cabinetMat = new THREE.MeshStandardMaterial({ color: 0x3A3A3A });
+
+  // ── FOUNDATION SLAB ──────────────────────────────────────────────────────────
+  const found = new THREE.Mesh(new THREE.BoxGeometry(W + 0.1, 0.1, D + 0.1), concMat);
+  found.position.y = 0.05;
+  found.castShadow = true;
+  found.receiveShadow = true;
+  group.add(found);
+
+  // ── GROUND FLOOR BODY (recessed) ─────────────────────────────────────────────
+  const gndBody = new THREE.Mesh(new THREE.BoxGeometry(gndW, gndH, gndD), gndBodyMat);
+  gndBody.position.y = baseY + gndH / 2;
+  gndBody.castShadow = true;
+  gndBody.receiveShadow = true;
+  group.add(gndBody);
+
+  // ── UPPER BODY (cantilevered — spans both upper floors) ──────────────────────
+  const upperBody = new THREE.Mesh(new THREE.BoxGeometry(W, upperH, D), concMat);
+  upperBody.position.y = baseY + gndH + upperH / 2;
+  upperBody.castShadow = true;
+  upperBody.receiveShadow = true;
+  group.add(upperBody);
+
+  // Limestone trim band at base of upper body (overhang soffit line)
+  const soffit = new THREE.Mesh(new THREE.BoxGeometry(W + 0.05, 0.08, D + 0.05), limeMat);
+  soffit.position.y = baseY + gndH + 0.04;
+  group.add(soffit);
+
+  // ── WAFFLE GRID FACADE — FRONT (6 columns × 2 rows) ──────────────────────────
+  const bayW_f  = 0.70;
+  const bayH_f  = 0.80;
+  const colStep = W / 6;       // 1.0 per column
+  const rowStep = upperH / 2;  // 1.5 per row (one per floor)
+  const frontZ  = D / 2 + 0.01;
+
+  for (let row = 0; row < 2; row++) {
+    const bayY = baseY + gndH + rowStep * (row + 0.5);
+    for (let col = 0; col < 6; col++) {
+      const bayX = -(W / 2) + colStep * (col + 0.5);
+      // Recessed bay panel (dark, mounted proud of wall to simulate indentation)
+      const panel = new THREE.Mesh(new THREE.BoxGeometry(bayW_f, bayH_f, 0.07), bayMat);
+      panel.position.set(bayX, bayY, frontZ);
+      group.add(panel);
+      // Window inside the bay
+      const win = new THREE.Mesh(new THREE.BoxGeometry(bayW_f * 0.64, bayH_f * 0.64, 0.04), winMat);
+      win.position.set(bayX, bayY, frontZ + 0.04);
+      group.add(win);
+    }
+  }
+
+  // ── WAFFLE GRID FACADE — SIDES (3 columns × 2 rows per side) ─────────────────
+  const sideBayW = 0.52;
+  const sideStep = D / 3;
+
+  for (const side of [-1, 1]) {
+    const sideX = side * (W / 2) + side * 0.01;
+    for (let row = 0; row < 2; row++) {
+      const bayY = baseY + gndH + rowStep * (row + 0.5);
+      for (let col = 0; col < 3; col++) {
+        const bayZ = -(D / 2) + sideStep * (col + 0.5);
+        const sp = new THREE.Mesh(new THREE.BoxGeometry(0.07, bayH_f, sideBayW), bayMat);
+        sp.position.set(sideX, bayY, bayZ);
+        group.add(sp);
+        const sw = new THREE.Mesh(new THREE.BoxGeometry(0.04, bayH_f * 0.64, sideBayW * 0.64), winMat);
+        sw.position.set(sideX + side * 0.04, bayY, bayZ);
+        group.add(sw);
+      }
+    }
+  }
+
+  // ── GROUND FLOOR PILLARS (5 thick concrete pilasters at front) ────────────────
+  const pilW = 0.32, pilD = 0.32;
+  for (let i = 0; i < 5; i++) {
+    const px = -(gndW / 2) + (gndW / 4) * i;
+    const pillar = new THREE.Mesh(new THREE.BoxGeometry(pilW, gndH + 0.06, pilD), concMat);
+    pillar.position.set(px, baseY + gndH / 2, gndD / 2 + pilD / 2);
+    pillar.castShadow = true;
+    group.add(pillar);
+  }
+
+  // ── DOUBLE DOORS ─────────────────────────────────────────────────────────────
+  for (const dx of [-0.38, 0.38]) {
+    const door = new THREE.Mesh(new THREE.BoxGeometry(0.56, 0.86, 0.06), doorMat);
+    door.position.set(dx, baseY + 0.43, gndD / 2 + 0.04);
+    group.add(door);
+  }
+
+  // Concrete lintel above doors
+  const lintel = new THREE.Mesh(new THREE.BoxGeometry(1.7, 0.09, 0.14), concMat);
+  lintel.position.set(0, baseY + 0.9, gndD / 2 + 0.04);
+  group.add(lintel);
+
+  // Sidelight windows beside doors
+  for (const sx of [-1.0, 1.0]) {
+    const sl = new THREE.Mesh(new THREE.BoxGeometry(0.18, 0.7, 0.05), winMat);
+    sl.position.set(sx, baseY + 0.42, gndD / 2 + 0.03);
+    group.add(sl);
+  }
+
+  // ── SIGN PLAQUE (just above overhang soffit, front center) ───────────────────
+  const signPlaque = new THREE.Mesh(new THREE.BoxGeometry(4.4, 0.22, 0.08), limeMat);
+  signPlaque.position.set(0, baseY + gndH + 0.22, D / 2 + 0.04);
+  group.add(signPlaque);
+
+  // ── AGENCY SEAL (above sign, centered between columns 3 & 4) ─────────────────
+  const sealR = 0.42;
+  const sealY = baseY + gndH + rowStep * 0.5;
+  const sealZ = D / 2 + 0.05;
+
+  const sealOuter = new THREE.Mesh(new THREE.CylinderGeometry(sealR, sealR, 0.07, 24), dkGoldMat);
+  sealOuter.rotation.x = Math.PI / 2;
+  sealOuter.position.set(0, sealY, sealZ);
+  group.add(sealOuter);
+
+  const sealInner = new THREE.Mesh(new THREE.CylinderGeometry(sealR * 0.72, sealR * 0.72, 0.09, 24), goldMat);
+  sealInner.rotation.x = Math.PI / 2;
+  sealInner.position.set(0, sealY, sealZ + 0.02);
+  group.add(sealInner);
+
+  // Five star rays radiating from seal center
+  for (let i = 0; i < 5; i++) {
+    const a = (i / 5) * Math.PI * 2;
+    const ray = new THREE.Mesh(new THREE.ConeGeometry(0.028, 0.13, 3), starMat);
+    ray.rotation.z = a - Math.PI / 2;
+    ray.position.set(Math.cos(a) * 0.09, sealY + Math.sin(a) * 0.09, sealZ + 0.07);
+    group.add(ray);
+  }
+
+  // ── FLAT ROOF ────────────────────────────────────────────────────────────────
+  const roofSlab = new THREE.Mesh(new THREE.BoxGeometry(W + 0.12, 0.15, D + 0.12), roofMat);
+  roofSlab.position.y = baseY + totalH + 0.075;
+  roofSlab.castShadow = true;
+  roofSlab.receiveShadow = true;
+  group.add(roofSlab);
+
+  // Low parapet around roof edge
+  const parH = 0.22, parT = 0.08;
+  const parY = baseY + totalH + 0.15 + parH / 2;
+  for (const [pw, pd, ox, oz] of [
+    [W + 0.12, parT, 0,              D / 2 + 0.06 - parT / 2],
+    [W + 0.12, parT, 0,             -(D / 2 + 0.06 - parT / 2)],
+    [parT, D + 0.12, -(W / 2 + 0.06 - parT / 2), 0],
+    [parT, D + 0.12,  (W / 2 + 0.06 - parT / 2), 0],
+  ]) {
+    const par = new THREE.Mesh(new THREE.BoxGeometry(pw, parH, pd), concMat);
+    par.position.set(ox, parY, oz);
+    group.add(par);
+  }
+
+  // Mechanical equipment boxes on roof
+  for (const mx of [-1.6, 1.6]) {
+    const mbox = new THREE.Mesh(new THREE.BoxGeometry(0.8, 0.38, 0.48), mechMat);
+    mbox.position.set(mx, baseY + totalH + 0.15 + 0.19, -0.3);
+    group.add(mbox);
+  }
+
+  // Antenna mast with red aircraft-warning orb at tip
+  const mast = new THREE.Mesh(new THREE.CylinderGeometry(0.025, 0.035, 1.6, 8), antMat);
+  mast.position.set(-0.8, baseY + totalH + 0.15 + 0.8, 0.2);
+  group.add(mast);
+
+  const mastOrb = createGlowOrb(0xFF0000);
+  mastOrb.position.set(-0.8, baseY + totalH + 0.15 + 1.62, 0.2);
+  group.add(mastOrb);
+
+  // ── SURVEILLANCE CAMERAS — red glow orbs under overhang ───────────────────────
+  // Center above entrance
+  const cam1 = createGlowOrb(0xFF0000);
+  cam1.position.set(0, baseY + gndH - 0.07, D / 2 - 0.06);
+  group.add(cam1);
+
+  // Opposite far corner (always watching)
+  const cam2 = createGlowOrb(0xFF0000);
+  cam2.position.set(W / 2 - 0.15, baseY + gndH - 0.07, -(D / 2 - 0.06));
+  group.add(cam2);
+
+  // ── SECURITY BOLLARDS (6 across the front) ────────────────────────────────────
+  const bStep = gndW / 5;
+  for (let i = 0; i < 6; i++) {
+    const bx = -(gndW / 2) + bStep * i;
+    const bollard = new THREE.Mesh(new THREE.CylinderGeometry(0.11, 0.13, 0.5, 8), concMat);
+    bollard.position.set(bx, 0.25, D / 2 + 0.75);
+    group.add(bollard);
+  }
+
+  // Jersey barriers flanking the entrance path
+  for (const bx of [-0.88, 0.88]) {
+    const jb = new THREE.Mesh(new THREE.BoxGeometry(0.22, 0.38, 0.55), barrMat);
+    jb.position.set(bx, 0.19, D / 2 + 0.46);
+    group.add(jb);
+  }
+
+  // ── ENTRANCE WALKWAY ─────────────────────────────────────────────────────────
+  const walkway = new THREE.Mesh(new THREE.BoxGeometry(1.3, 0.04, 1.4), limeMat);
+  walkway.position.set(0, 0.02, D / 2 + 0.72);
+  walkway.receiveShadow = true;
+  group.add(walkway);
+
+  // Two shallow concrete steps up to door level
+  for (let s = 0; s < 2; s++) {
+    const step = new THREE.Mesh(new THREE.BoxGeometry(1.5 - s * 0.15, 0.055, 0.22), limeMat);
+    step.position.set(0, baseY + s * 0.055 + 0.028, D / 2 + 0.13 - s * 0.2);
+    group.add(step);
+  }
+
+  // ── FLAGPOLE (right of entrance, rises above roofline) ────────────────────────
+  const poleH = 5.0;
+  const poleX = gndW / 2 + 0.45;   // right of building
+  const poleZ = gndD / 2 + 0.25;
+  const pole  = new THREE.Mesh(new THREE.CylinderGeometry(0.025, 0.035, poleH, 8), poleMat);
+  pole.position.set(poleX, poleH / 2, poleZ);
+  group.add(pole);
+
+  // Flag: blue top, white stripe, red bottom — at top of pole
+  const flagTopY = poleH - 0.14;
+  const flagOffX = poleX + 0.3;
+
+  const flagBlue = new THREE.Mesh(new THREE.BoxGeometry(0.6, 0.22, 0.02),
+    new THREE.MeshStandardMaterial({ color: 0x002868 }));
+  flagBlue.position.set(flagOffX, flagTopY, poleZ);
+  group.add(flagBlue);
+
+  const flagWhite = new THREE.Mesh(new THREE.BoxGeometry(0.6, 0.04, 0.02),
+    new THREE.MeshStandardMaterial({ color: 0xFFFFFF }));
+  flagWhite.position.set(flagOffX, flagTopY - 0.13, poleZ);
+  group.add(flagWhite);
+
+  const flagRed = new THREE.Mesh(new THREE.BoxGeometry(0.6, 0.22, 0.02),
+    new THREE.MeshStandardMaterial({ color: 0xBF0A30 }));
+  flagRed.position.set(flagOffX, flagTopY - 0.295, poleZ);
+  group.add(flagRed);
+
+  // ── INTERIOR DETAILS (visible through glass) ──────────────────────────────────
+  // Security arch (metal detector) just inside the doors
+  const archMesh = new THREE.Mesh(new THREE.BoxGeometry(0.65, 0.78, 0.05), detectorMat);
+  archMesh.position.set(0, baseY + 0.39, gndD / 2 - 0.26);
+  group.add(archMesh);
+
+  // Reception desk
+  const recDesk = new THREE.Mesh(new THREE.BoxGeometry(1.1, 0.28, 0.36), walnutMat);
+  recDesk.position.set(0, baseY + 0.14, gndD / 2 - 0.72);
+  group.add(recDesk);
+
+  // Glowing computer orb on desk
+  const compOrb = createGlowOrb(0x00CC66);
+  compOrb.position.set(0.28, baseY + 0.3, gndD / 2 - 0.72);
+  group.add(compOrb);
+
+  // Second floor — agent bullpen (3 rows × 4 desks)
+  for (let row = 0; row < 3; row++) {
+    for (let col = 0; col < 4; col++) {
+      const desk = new THREE.Mesh(new THREE.BoxGeometry(0.30, 0.04, 0.17), deskMat);
+      desk.position.set(-1.15 + col * 0.82, baseY + gndH + 0.3, -(D / 2) + 0.3 + row * 0.42);
+      group.add(desk);
+    }
+  }
+
+  // Evidence board on back wall (second floor)
+  const board = new THREE.Mesh(new THREE.BoxGeometry(1.4, 0.64, 0.04), boardMat);
+  board.position.set(-1.4, baseY + gndH + 0.58, -(D / 2) + 0.03);
+  group.add(board);
+
+  // Case file pins on evidence board
+  for (const [px, py, c] of [
+    [-1.72, baseY + gndH + 0.74, 0xCC0000],
+    [-1.44, baseY + gndH + 0.54, 0x2255AA],
+    [-1.16, baseY + gndH + 0.70, 0xCC0000],
+    [-0.94, baseY + gndH + 0.56, 0x2255AA],
+  ]) {
+    const pin = new THREE.Mesh(new THREE.BoxGeometry(0.09, 0.09, 0.02),
+      new THREE.MeshStandardMaterial({ color: c }));
+    pin.position.set(px, py, -(D / 2) + 0.06);
+    group.add(pin);
+  }
+
+  // Third floor — executive office
+  const execDesk = new THREE.Mesh(new THREE.BoxGeometry(0.55, 0.05, 0.30), deskMat);
+  execDesk.position.set(0, baseY + gndH + flrH + 0.28, 0.1);
+  group.add(execDesk);
+
+  const nameplate = new THREE.Mesh(new THREE.BoxGeometry(0.14, 0.034, 0.034),
+    new THREE.MeshStandardMaterial({ color: 0xFFD700, metalness: 0.5 }));
+  nameplate.position.set(0, baseY + gndH + flrH + 0.30, 0.2);
+  group.add(nameplate);
+
+  const cabinet = new THREE.Mesh(new THREE.BoxGeometry(0.22, 0.65, 0.18), cabinetMat);
+  cabinet.position.set(1.4, baseY + gndH + flrH + 0.33, -(D / 2) + 0.12);
+  group.add(cabinet);
+
+  // ── FLUORESCENT GLOW ORBS (soul-crushing office lighting) ────────────────────
+  // Second floor: 4 orbs
+  for (let i = 0; i < 4; i++) {
+    const orb = createGlowOrb(0xE8E4D9);
+    orb.position.set(-1.5 + i * 1.0, baseY + gndH + flrH - 0.1, 0);
+    group.add(orb);
+  }
+
+  // Third floor: 2 orbs
+  for (let i = 0; i < 2; i++) {
+    const orb = createGlowOrb(0xE8E4D9);
+    orb.position.set(-0.7 + i * 1.4, baseY + gndH + upperH - 0.1, 0);
+    group.add(orb);
+  }
+
+  // ── PLAQUE ANCHOR ────────────────────────────────────────────────────────────
+  buildPlaque(group, building, D / 2 + 0.12, 2.2);
+};
+
+CUSTOM_BUILDERS['sawasdi-baan-thai'] = function (group, building) {
+  const W = 2.6;        // main building width
+  const D = 2.0;        // main building depth
+  const wallH = 1.7;    // wall height
+  const baseH = 0.12;   // foundation slab height
+  const verandaD = 0.8; // veranda depth (extends in +Z / front direction)
+
+  // Materials
+  const wallMat     = new THREE.MeshStandardMaterial({ color: 0x8B4513, roughness: 0.85 });
+  const foundMat    = new THREE.MeshStandardMaterial({ color: 0x8B6F4E, roughness: 0.9 });
+  const roofMat     = new THREE.MeshStandardMaterial({ color: 0x5D3A1A, roughness: 0.8 });
+  const doorMat     = new THREE.MeshStandardMaterial({ color: 0x2E1A0E, roughness: 0.8 });
+  const darkOakMat  = new THREE.MeshStandardMaterial({ color: 0x4A2E0E, roughness: 0.8 });
+  const goldMat     = new THREE.MeshStandardMaterial({ color: 0xF6A623, roughness: 0.4, metalness: 0.3 });
+  const signMat     = new THREE.MeshStandardMaterial({ color: 0xC2185B, roughness: 0.6 });
+  const creamMat    = new THREE.MeshStandardMaterial({ color: 0xFEF3C7, roughness: 0.7 });
+  const woodMat     = new THREE.MeshStandardMaterial({ color: 0x8B6F4E, roughness: 0.85 });
+  const darkWoodMat = new THREE.MeshStandardMaterial({ color: 0x6B3A1F, roughness: 0.9 });
+  const ironMat     = new THREE.MeshStandardMaterial({ color: 0x374151, roughness: 0.6 });
+  const winMat      = new THREE.MeshStandardMaterial({
+    color: 0xbfdbfe, emissive: 0x3b82f6, emissiveIntensity: 0.15,
+    transparent: true, opacity: 0.35, roughness: 0.1,
+  });
+  const interiorMat = new THREE.MeshStandardMaterial({
+    color: 0xFEF3C7, emissive: 0xfbbf24, emissiveIntensity: 0.12,
+  });
+
+  // ── FOUNDATION (spans main building + veranda) ─────────────────────────
+  const found = new THREE.Mesh(
+    new THREE.BoxGeometry(W + 0.2, baseH, D + verandaD + 0.1),
+    foundMat
+  );
+  found.position.set(0, baseH / 2, verandaD / 2);
+  found.castShadow = true;
+  found.receiveShadow = true;
+  group.add(found);
+
+  // ── MAIN WALLS ─────────────────────────────────────────────────────────
+  const walls = new THREE.Mesh(new THREE.BoxGeometry(W, wallH, D), wallMat);
+  walls.position.y = baseH + wallH / 2;
+  walls.castShadow = true;
+  walls.receiveShadow = true;
+  group.add(walls);
+
+  // Interior warm back wall (visible through windows)
+  const iWall = new THREE.Mesh(new THREE.BoxGeometry(W - 0.2, wallH - 0.2, 0.04), interiorMat);
+  iWall.position.set(0, baseH + wallH / 2, -D / 2 + 0.1);
+  group.add(iWall);
+
+  // ── HORIZONTAL TIMBER TRIM BANDS (front facade) ────────────────────────
+  for (const trimY of [baseH, baseH + wallH * 0.5, baseH + wallH]) {
+    const trim = new THREE.Mesh(new THREE.BoxGeometry(W + 0.04, 0.05, 0.04), darkOakMat);
+    trim.position.set(0, trimY + 0.025, D / 2 + 0.02);
+    group.add(trim);
+  }
+
+  // ── DOOR (offset right to leave room for windows on left) ──────────────
+  const door = new THREE.Mesh(new THREE.BoxGeometry(0.4, 0.7, 0.06), doorMat);
+  door.position.set(0.5, baseH + 0.36, D / 2 + 0.04);
+  group.add(door);
+
+  // ── FRONT WINDOWS (left half of facade) ────────────────────────────────
+  for (const wx of [-0.9, -0.3]) {
+    const win = new THREE.Mesh(new THREE.BoxGeometry(0.35, 0.35, 0.05), winMat);
+    win.position.set(wx, baseH + wallH * 0.6, D / 2 + 0.04);
+    group.add(win);
+    const frame = new THREE.Mesh(new THREE.BoxGeometry(0.39, 0.39, 0.03), darkOakMat);
+    frame.position.set(wx, baseH + wallH * 0.6, D / 2 + 0.02);
+    group.add(frame);
+  }
+
+  // ── OPEN KITCHEN COUNTER (left side of facade) ─────────────────────────
+  const counter = new THREE.Mesh(new THREE.BoxGeometry(0.9, 0.08, 0.5), darkWoodMat);
+  counter.position.set(-W / 2 + 0.45, baseH + 0.55, D / 2 + 0.06);
+  counter.castShadow = true;
+  group.add(counter);
+
+  // ── MAIN ROOF (low-pitched gable) ──────────────────────────────────────
+  const roofSlab = new THREE.Mesh(new THREE.BoxGeometry(W + 0.4, 0.12, D + 0.3), roofMat);
+  roofSlab.position.set(0, baseH + wallH + 0.06, 0);
+  roofSlab.castShadow = true;
+  group.add(roofSlab);
+
+  const ridge = new THREE.Mesh(new THREE.BoxGeometry(W + 0.4, 0.14, 0.12), roofMat);
+  ridge.position.set(0, baseH + wallH + 0.19, 0);
+  group.add(ridge);
+
+  // Upswept eave tips (chofa silhouette) at each roof corner
+  for (const [ex, ez, rx, rz] of [
+    [-W / 2 - 0.18,  D / 2 + 0.14, -0.45,  0.5],
+    [ W / 2 + 0.18,  D / 2 + 0.14,  0.45,  0.5],
+    [-W / 2 - 0.18, -D / 2 - 0.14, -0.45, -0.5],
+    [ W / 2 + 0.18, -D / 2 - 0.14,  0.45, -0.5],
+  ]) {
+    const tip = new THREE.Mesh(new THREE.ConeGeometry(0.03, 0.25, 6), goldMat);
+    tip.position.set(ex, baseH + wallH + 0.13, ez);
+    tip.rotation.z = rx;
+    tip.rotation.x = rz;
+    group.add(tip);
+  }
+
+  // ── VERANDA PLATFORM ───────────────────────────────────────────────────
+  const verandaFloor = new THREE.Mesh(new THREE.BoxGeometry(W + 0.1, 0.06, verandaD), foundMat);
+  verandaFloor.position.set(0, baseH + 0.03, D / 2 + verandaD / 2);
+  verandaFloor.receiveShadow = true;
+  group.add(verandaFloor);
+
+  // Veranda roof
+  const verandaRoof = new THREE.Mesh(new THREE.BoxGeometry(W + 0.4, 0.08, verandaD + 0.15), roofMat);
+  verandaRoof.position.set(0, baseH + wallH + 0.04, D / 2 + verandaD / 2);
+  verandaRoof.castShadow = true;
+  group.add(verandaRoof);
+
+  // Veranda posts (4 corners)
+  for (const [px, pz] of [
+    [-W / 2 + 0.2, D / 2 + 0.1],
+    [ W / 2 - 0.2, D / 2 + 0.1],
+    [-W / 2 + 0.2, D / 2 + verandaD - 0.1],
+    [ W / 2 - 0.2, D / 2 + verandaD - 0.1],
+  ]) {
+    const post = new THREE.Mesh(new THREE.CylinderGeometry(0.04, 0.04, wallH, 8), darkWoodMat);
+    post.position.set(px, baseH + wallH / 2, pz);
+    post.castShadow = true;
+    group.add(post);
+  }
+
+  // ── SIGNBOARD ──────────────────────────────────────────────────────────
+  const sign = new THREE.Mesh(new THREE.BoxGeometry(1.0, 0.35, 0.05), signMat);
+  sign.position.set(0, baseH + wallH * 0.85, D / 2 + 0.08);
+  group.add(sign);
+  // Gold border
+  for (const [bw, bh, bx, by] of [
+    [1.06, 0.03,   0,    baseH + wallH * 0.85 + 0.19],
+    [1.06, 0.03,   0,    baseH + wallH * 0.85 - 0.19],
+    [0.03, 0.41, -0.52,  baseH + wallH * 0.85],
+    [0.03, 0.41,  0.52,  baseH + wallH * 0.85],
+  ]) {
+    const b = new THREE.Mesh(new THREE.BoxGeometry(bw, bh, 0.04), goldMat);
+    b.position.set(bx, by, D / 2 + 0.09);
+    group.add(b);
+  }
+  // Subtitle bar
+  const subtitle = new THREE.Mesh(new THREE.BoxGeometry(0.7, 0.1, 0.04), creamMat);
+  subtitle.position.set(0, baseH + wallH * 0.85 - 0.28, D / 2 + 0.08);
+  group.add(subtitle);
+
+  // ── HANGING PAPER LANTERNS (along veranda roof edge) ───────────────────
+  for (let i = 0; i < 4; i++) {
+    const lx = -W / 2 + 0.3 + i * (W - 0.45) / 3;
+    const lz = D / 2 + verandaD - 0.05;
+    const string = new THREE.Mesh(new THREE.CylinderGeometry(0.008, 0.008, 0.2, 4), ironMat);
+    string.position.set(lx, baseH + wallH - 0.1, lz);
+    group.add(string);
+    const lantern = createGlowOrb(0xF6A623);
+    lantern.scale.set(1.2, 1.6, 1.2);
+    lantern.position.set(lx, baseH + wallH - 0.28, lz);
+    group.add(lantern);
+  }
+
+  // ── STRING LIGHTS (veranda front edge) ─────────────────────────────────
+  for (let i = 0; i < 6; i++) {
+    const lx = -W / 2 + 0.22 + i * (W - 0.35) / 5;
+    const orb = createGlowOrb(0xFBBF24);
+    orb.scale.setScalar(0.32);
+    orb.position.set(lx, baseH + wallH + 0.02, D / 2 + verandaD + 0.05);
+    group.add(orb);
+  }
+
+  // ── VERANDA DINING TABLES & BENCHES ────────────────────────────────────
+  for (const tx of [-0.65, 0.65]) {
+    const tbl = new THREE.Mesh(new THREE.BoxGeometry(0.35, 0.15, 0.25), woodMat);
+    tbl.position.set(tx, baseH + 0.06 + 0.075, D / 2 + 0.44);
+    group.add(tbl);
+    for (const bz of [-0.22, 0.22]) {
+      const bench = new THREE.Mesh(new THREE.BoxGeometry(0.3, 0.06, 0.08), darkWoodMat);
+      bench.position.set(tx, baseH + 0.06 + 0.03, D / 2 + 0.44 + bz);
+      group.add(bench);
+    }
+  }
+
+  // ── POTTED PLANTS (flanking door) ──────────────────────────────────────
+  for (const px of [0.1, 1.05]) {
+    const pot = new THREE.Mesh(new THREE.CylinderGeometry(0.06, 0.05, 0.08, 8), wallMat);
+    pot.position.set(px, baseH + 0.04, D / 2 + 0.12);
+    group.add(pot);
+    const foliage = new THREE.Mesh(new THREE.SphereGeometry(0.1, 7, 5),
+      new THREE.MeshStandardMaterial({ color: 0x2E7D32 }));
+    foliage.position.set(px, baseH + 0.18, D / 2 + 0.12);
+    foliage.castShadow = true;
+    group.add(foliage);
+  }
+
+  // ── ACCESSIBILITY RAMP ─────────────────────────────────────────────────
+  const ramp = new THREE.Mesh(new THREE.BoxGeometry(0.5, 0.06, 0.2),
+    new THREE.MeshStandardMaterial({ color: 0xD1D5DB }));
+  ramp.position.set(0, 0.03, D / 2 + verandaD + 0.1);
+  group.add(ramp);
+
+  // ── STREET-FOOD CART (right side +X) ───────────────────────────────────
+  const cartX = W / 2 + 0.42;
+  const cartZ = D / 2 - 0.1;
+  const cart = new THREE.Mesh(new THREE.BoxGeometry(0.6, 0.45, 0.5), woodMat);
+  cart.position.set(cartX, baseH + 0.225, cartZ);
+  cart.castShadow = true;
+  group.add(cart);
+  // Wheels
+  for (const wz of [cartZ - 0.22, cartZ + 0.22]) {
+    const wheel = new THREE.Mesh(new THREE.CylinderGeometry(0.1, 0.1, 0.04, 10), ironMat);
+    wheel.rotation.x = Math.PI / 2;
+    wheel.position.set(cartX + 0.32, 0.1, wz);
+    group.add(wheel);
+  }
+  // Striped awning (3 strips, alternating red/white)
+  for (let i = 0; i < 3; i++) {
+    const strip = new THREE.Mesh(new THREE.BoxGeometry(0.65, 0.02, 0.14),
+      new THREE.MeshStandardMaterial({ color: i % 2 === 0 ? 0xDC2626 : 0xFAFAFA, roughness: 0.7 }));
+    strip.position.set(cartX, baseH + 0.57 + i * 0.045, cartZ - 0.12 + i * 0.04);
+    strip.rotation.x = -0.25;
+    group.add(strip);
+  }
+  // Chalkboard menu
+  const chalk = new THREE.Mesh(new THREE.BoxGeometry(0.2, 0.15, 0.02),
+    new THREE.MeshStandardMaterial({ color: 0x1F2937 }));
+  chalk.position.set(cartX, baseH + 0.45 + 0.075, cartZ + 0.28);
+  group.add(chalk);
+
+  // ── INTERIOR: WOK STATION (left side, behind kitchen counter) ──────────
+  const stove = new THREE.Mesh(new THREE.BoxGeometry(0.3, 0.04, 0.28), ironMat);
+  stove.position.set(-W / 2 + 0.45, baseH + 0.57, 0.1);
+  group.add(stove);
+  for (const wox of [-0.1, 0.1]) {
+    const wok = new THREE.Mesh(new THREE.CylinderGeometry(0.055, 0.04, 0.025, 8), ironMat);
+    wok.position.set(-W / 2 + 0.45 + wox, baseH + 0.595, 0.1);
+    group.add(wok);
+    // Steam orbs rising above wok
+    for (let s = 0; s < 3; s++) {
+      const steam = new THREE.Mesh(new THREE.SphereGeometry(0.04, 5, 4),
+        new THREE.MeshBasicMaterial({ color: 0xffffff, transparent: true, opacity: 0.22 - s * 0.04 }));
+      steam.position.set(-W / 2 + 0.45 + wox, baseH + 0.67 + s * 0.1, 0.1);
+      group.add(steam);
+    }
+  }
+
+  // Spice jar shelf + jars
+  const shelf = new THREE.Mesh(new THREE.BoxGeometry(0.28, 0.02, 0.06), darkWoodMat);
+  shelf.position.set(-W / 2 + 0.45, baseH + wallH * 0.56, -D / 2 + 0.18);
+  group.add(shelf);
+  for (let j = 0; j < 4; j++) {
+    const jar = new THREE.Mesh(new THREE.CylinderGeometry(0.014, 0.014, 0.04, 6),
+      new THREE.MeshStandardMaterial({ color: [0xDC2626, 0x2E7D32, 0xF6A623, 0x8B4513][j] }));
+    jar.position.set(-W / 2 + 0.34 + j * 0.065, baseH + wallH * 0.56 + 0.03, -D / 2 + 0.18);
+    group.add(jar);
+  }
+
+  // Hanging pans (from ceiling)
+  for (const px of [-0.25, 0.0]) {
+    const rod = new THREE.Mesh(new THREE.CylinderGeometry(0.005, 0.005, 0.2, 4), ironMat);
+    rod.position.set(-W / 2 + 0.45 + px, baseH + wallH - 0.1, 0.1);
+    group.add(rod);
+    const pan = new THREE.Mesh(new THREE.CylinderGeometry(0.04, 0.04, 0.012, 8), ironMat);
+    pan.position.set(-W / 2 + 0.45 + px, baseH + wallH - 0.21, 0.1);
+    group.add(pan);
+  }
+
+  // ── INTERIOR: DINING TABLES + BOWLS + PENDANT LAMPS ────────────────────
+  for (const [dtx, dtz] of [[0.3, 0.25], [0.3, -0.3]]) {
+    const dtable = new THREE.Mesh(new THREE.BoxGeometry(0.3, 0.12, 0.25), woodMat);
+    dtable.position.set(dtx, baseH + 0.45, dtz);
+    group.add(dtable);
+    const bowl = new THREE.Mesh(new THREE.SphereGeometry(0.025, 6, 4),
+      new THREE.MeshStandardMaterial({ color: 0xF0F9FF }));
+    bowl.scale.y = 0.5;
+    bowl.position.set(dtx, baseH + 0.515, dtz);
+    group.add(bowl);
+    // Pendant lamp
+    const lampRod = new THREE.Mesh(new THREE.CylinderGeometry(0.006, 0.006, 0.28, 4), ironMat);
+    lampRod.position.set(dtx, baseH + wallH - 0.14, dtz);
+    group.add(lampRod);
+    const shade = new THREE.Mesh(new THREE.SphereGeometry(0.05, 7, 5),
+      new THREE.MeshStandardMaterial({ color: 0xD4A574, roughness: 0.7 }));
+    shade.position.set(dtx, baseH + wallH - 0.31, dtz);
+    group.add(shade);
+    const lampGlow = createGlowOrb(0xFBBF24);
+    lampGlow.scale.setScalar(0.45);
+    lampGlow.position.set(dtx, baseH + wallH - 0.31, dtz);
+    group.add(lampGlow);
+  }
+
+  // ── INTERIOR: BAMBOO STEAMER BASKETS ───────────────────────────────────
+  for (let bs = 0; bs < 3; bs++) {
+    const stmr = new THREE.Mesh(new THREE.CylinderGeometry(0.05, 0.05, 0.03, 8),
+      new THREE.MeshStandardMaterial({ color: 0xC4A35A }));
+    stmr.position.set(-W / 2 + 0.3, baseH + 0.49 + bs * 0.034, -D / 2 + 0.2);
+    group.add(stmr);
+  }
+
+  // ── INTERIOR: BACK MENU BOARD ───────────────────────────────────────────
+  const mboard = new THREE.Mesh(new THREE.BoxGeometry(0.15, 0.12, 0.02), ironMat);
+  mboard.position.set(W / 2 - 0.2, baseH + wallH * 0.5, -D / 2 + 0.06);
+  group.add(mboard);
+  const mtext = new THREE.Mesh(new THREE.BoxGeometry(0.11, 0.015, 0.015), creamMat);
+  mtext.position.set(W / 2 - 0.2, baseH + wallH * 0.5 + 0.02, -D / 2 + 0.08);
+  group.add(mtext);
+
+  // ── AMBIENT INTERIOR GLOW ──────────────────────────────────────────────
+  const glow = createGlowOrb(0xFBBF24);
+  glow.scale.setScalar(0.8);
+  glow.position.set(0, baseH + wallH * 0.5, 0);
+  group.add(glow);
+
+  // ── PLAQUE ANCHOR ──────────────────────────────────────────────────────
+  buildPlaque(group, building, D / 2 + verandaD, baseH + wallH * 0.65);
+};
+
 // Distant hills
 export function createHills() {
   const group = new THREE.Group();


### PR DESCRIPTION
## Problem

Both **Federal Bureau of AI Investigation** (@johnturek, issue #51) and **S̄wạs̄dī Bāan Thai** (@ritthikrairw, issue #47) were added to `town.json` but their `CUSTOM_BUILDERS` functions were missing from `js/buildings.js`. This caused both buildings to render as default colored boxes instead of their intended custom designs.

## Solution

This PR adds both complete builder functions from their original PR branches:
- `CUSTOM_BUILDERS['federal-bureau-of-ai-investigation']` — Brutalist FBI Hoover Building with waffle-grid facade
- `CUSTOM_BUILDERS['sawasdi-baan-thai']` — Thai restaurant with veranda, wok station, and hanging lanterns

## Details

- **FBI building (issue #51)**: PR #57 was closed without merging the builder code. The `town.json` entry somehow got into main, but the rendering code did not.
- **Thai restaurant (issue #47)**: PR #53 was merged, but the builder function was lost in the merge.

Both buildings now render correctly with their full custom geometry.

## Verification

The site should load without errors and both buildings should display their detailed custom architecture instead of default boxes.

---

**Supersedes:** PR #57 (FBI building — never merged)  
**Corrects:** PR #53 (Thai restaurant — missing builder)